### PR TITLE
Fix parent directories not created on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 .git/
+.idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'ghr'",
+            "cargo": {
+                "args": ["build", "--bin=ghr", "--package=ghr"],
+                "filter": {
+                    "name": "ghr",
+                    "kind": "bin"
+                }
+            },
+            "args": ["clone"],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'ghr'",
+            "cargo": {
+                "args": ["test", "--no-run", "--bin=ghr", "--package=ghr"],
+                "filter": {
+                    "name": "ghr",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1021,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "dunce",
  "gh-config",
  "git2",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ walkdir = "2.5"
 
 gh-config = { version = "0.4.1", optional = true }
 octocrab = { version = "0.42.1", optional = true }
+dunce = "1.0.5"
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.58.0"

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -10,7 +10,7 @@ use console::style;
 use git2::Repository;
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::Config;
 use crate::console::{MultiSpinner, Spinner};
@@ -185,6 +185,11 @@ impl Cmd {
         if path.exists() {
             warn!("Directory already exists. Skipping cloning the repository...");
         } else {
+            debug!(
+                "Generating parent directories: {}",
+                path.to_str().unwrap_or_default(),
+            );
+
             let parent_path = path
                 .parent()
                 .ok_or_else(|| {

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -1,7 +1,7 @@
+use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use std::fs::create_dir_all;
 
 use anyhow::{anyhow, Result};
 use async_hofs::iter::AsyncMapExt;

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use std::fs::create_dir_all;
 
 use anyhow::{anyhow, Result};
 use async_hofs::iter::AsyncMapExt;
@@ -184,6 +185,18 @@ impl Cmd {
         if path.exists() {
             warn!("Directory already exists. Skipping cloning the repository...");
         } else {
+            let parent_path = path
+                .parent()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Failed to determine parent path for the repository's new location: {}",
+                        path.to_string_lossy()
+                    )
+                })?
+                .to_path_buf();
+
+            create_dir_all(parent_path)?;
+
             let mut retries = 0;
             while let Err(e) = config.git.strategy.clone.clone_repository(
                 url.clone(),

--- a/src/git/strategy/cli.rs
+++ b/src/git/strategy/cli.rs
@@ -1,4 +1,4 @@
-use std::path::{Path};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::anyhow;
@@ -9,7 +9,6 @@ use crate::git::{CheckoutBranch, CloneOptions, CloneRepository, Fetch};
 pub struct Cli;
 
 impl CloneRepository for Cli {
-
     fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> anyhow::Result<()>
     where
         U: ToString,

--- a/src/git/strategy/cli.rs
+++ b/src/git/strategy/cli.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path};
 use std::process::Command;
 
 use anyhow::anyhow;
@@ -9,6 +9,7 @@ use crate::git::{CheckoutBranch, CloneOptions, CloneRepository, Fetch};
 pub struct Cli;
 
 impl CloneRepository for Cli {
+
     fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> anyhow::Result<()>
     where
         U: ToString,
@@ -16,10 +17,14 @@ impl CloneRepository for Cli {
     {
         debug!("Cloning the repository using CLI strategy");
 
+        // Convert `path` to `&Path` and pass it to `dunce::simplified`
+        let simplified_path = dunce::simplified(path.as_ref());
+        let path_local = simplified_path.to_string_lossy(); // Use lossless conversion to String
+
         let mut args = vec![
             "clone".to_string(),
             url.to_string(),
-            path.as_ref().to_string_lossy().to_string(),
+            path_local.into_owned(), // Convert Cow<str> into String
         ];
 
         if let Some(recursive) = options.recursive.as_ref() {
@@ -38,6 +43,7 @@ impl CloneRepository for Cli {
             args.push(format!("--branch={branch}"));
         }
 
+        debug!("Executing: git {}", args.join(" "));
         let output = Command::new("git").args(args).output()?;
         match output.status.success() {
             true => Ok(()),

--- a/src/path.rs
+++ b/src/path.rs
@@ -46,7 +46,7 @@ impl<'a> Path<'a> {
     }
 }
 
-impl<'a> Display for Path<'a> {
+impl Display for Path<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}/{}", self.host, self.owner, self.repo)
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -5,7 +5,6 @@ use std::result::Result as StdResult;
 
 use anyhow::Result;
 use git2::Repository;
-use itertools::Itertools;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -92,10 +91,9 @@ impl Serialize for Configs {
     {
         let mut map = serializer.serialize_map(None)?;
 
-        self.to_toml()
-            .iter()
-            .map(|(k, v)| map.serialize_entry(k, v))
-            .try_collect()?;
+        for (k, v) in self.to_toml() {
+            map.serialize_entry(&k, &v)?;
+        }
 
         map.end()
     }


### PR DESCRIPTION

This pull request fixes #1 and includes several changes across multiple files to add new features, improve debugging, and clean up the codebase. The most important changes are grouped by theme below:

### Copilot Workspace

Add logic to create parent directories before cloning the repository in `src/cmd/clone.rs`.

* Import `create_dir_all` from `std::fs`.
* Determine the parent path for the repository's new location.
* Use `create_dir_all` to create parent directories before cloning the repository.

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joelvaneenwyk/ghr/issues/1?shareId=d72570d8-67d8-40ea-aa2e-01996f8ac99f).

### Debugging and Logging Improvements

* Added new debug configuration for LLDB in `.vscode/launch.json` to facilitate debugging the `ghr` executable and its unit tests.
* Added `debug` logging statements in `src/cmd/clone.rs` to provide more detailed information during directory creation and repository cloning. [[1]](diffhunk://#diff-e1367e6eed3991cf073cb81cb55a25a33b987a5f18452ce18850786ce75f3a19L12-R13) [[2]](diffhunk://#diff-e1367e6eed3991cf073cb81cb55a25a33b987a5f18452ce18850786ce75f3a19R188-R204)
* Added a debug log to display the executed `git` command in `src/git/strategy/cli.rs`.

### Dependency and Code Enhancements

* Added the `dunce` crate to `Cargo.toml` to simplify file paths on Windows.
* Utilized `dunce::simplified` to handle path simplification in `src/git/strategy/cli.rs`.

### Code Cleanup

* Removed unused import `itertools::Itertools` from `src/profile.rs`.
* Simplified the serialization logic in `src/profile.rs` by replacing `try_collect` with a simple loop.
* Changed the lifetime parameter in the `Display` implementation for `Path` in `src/path.rs` to use an anonymous lifetime.

These changes collectively enhance the debugging capabilities, improve code readability, and ensure better path handling on Windows systems.